### PR TITLE
Allow to tune TopicMetadataRefreshInterval

### DIFF
--- a/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
@@ -48,7 +48,8 @@ namespace Vektonn.DataSource.Kafka
                 EnableAutoCommit = false,
                 AutoCommitIntervalMs = 0,
                 AutoOffsetReset = AutoOffsetReset.Earliest,
-                FetchWaitMaxMs = (int)kafkaConsumerConfig.MaxFetchDelay.TotalMilliseconds
+                FetchWaitMaxMs = (int)kafkaConsumerConfig.MaxFetchDelay.TotalMilliseconds,
+                TopicMetadataRefreshIntervalMs = (int)kafkaConsumerConfig.TopicMetadataRefreshInterval.TotalMilliseconds
             };
 
             var consumerBuilder = new ConsumerBuilder<byte[], byte[]>(consumerConfig)

--- a/src/Vektonn.DataSource/Kafka/KafkaConsumerConfig.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaConsumerConfig.cs
@@ -14,6 +14,7 @@ namespace Vektonn.DataSource.Kafka
         }
 
         public string[] BootstrapServers { get; }
+        public TimeSpan TopicMetadataRefreshInterval { get; set; } = TimeSpan.FromSeconds(10);
         public TimeSpan MaxFetchDelay { get; set; } = TimeSpan.FromMilliseconds(100);
         public TimeSpan MinRetryDelay { get; set; } = TimeSpan.FromMilliseconds(100);
         public TimeSpan MaxRetryDelay { get; set; } = TimeSpan.FromSeconds(10);

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7",
+  "version": "0.7-pre",
   "assemblyVersion": {
     "precision": "build"
   },

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7-pre",
+  "version": "0.7",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
Allow to tune `TopicMetadataRefreshInterval` to speed up new kafka topics discovery by consumer