### PR TITLE
Allow user tune KafkaConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs/
+.idea/
 bin/
 obj/
 *.csproj.user

--- a/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
@@ -41,10 +41,7 @@ namespace Vektonn.DataSource.Kafka
 
             committedOffsets = new CommittedOffsets(this.log);
 
-            var consumerConfig = new ConsumerConfig();
-            kafkaConsumerConfig.CustomizeConsumerConfig(consumerConfig);
-            kafkaConsumerConfig.CustomizeConsumerConfigInternal(consumerConfig);
-
+            var consumerConfig = kafkaConsumerConfig.GetConfluentConsumerConfig();
             consumer = BuildConsumer(consumerConfig);
         }
 

--- a/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
@@ -76,7 +76,7 @@ namespace Vektonn.DataSource.Kafka
 
         private IConsumer<byte[], byte[]> BuildConsumer(ConsumerConfig consumerConfig)
         {
-            var consumerBuilder = new ConsumerBuilder<byte[], byte[]>(consumerConfig)
+            return new ConsumerBuilder<byte[], byte[]>(consumerConfig)
                 .SetKeyDeserializer(Deserializers.ByteArray)
                 .SetValueDeserializer(Deserializers.ByteArray)
                 .SetErrorHandler(
@@ -90,8 +90,8 @@ namespace Vektonn.DataSource.Kafka
                         LogExtensions.Info(this.log, $"Assigned {topicPartitions.Count} partitions with offsetsToConsumeFrom: {string.Join("; ", offsetsToConsumeFrom.Select(x => x.ToString()))}");
                         firstAssignmentSignal.Set();
                         return offsetsToConsumeFrom;
-                    });
-            return consumerBuilder.Build();
+                    })
+                .Build();
         }
 
         private async Task ConsumeLoopAsync(TaskCompletionSource initializationTcs, CancellationToken cancellationToken)

--- a/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
@@ -41,34 +41,11 @@ namespace Vektonn.DataSource.Kafka
 
             committedOffsets = new CommittedOffsets(this.log);
 
-            var consumerConfig = new ConsumerConfig
-            {
-                BootstrapServers = string.Join(",", kafkaConsumerConfig.BootstrapServers),
-                GroupId = $"Vektonn-{Guid.NewGuid():N}",
-                EnableAutoCommit = false,
-                AutoCommitIntervalMs = 0,
-                AutoOffsetReset = AutoOffsetReset.Earliest,
-                FetchWaitMaxMs = (int)kafkaConsumerConfig.MaxFetchDelay.TotalMilliseconds,
-                TopicMetadataRefreshIntervalMs = (int)kafkaConsumerConfig.TopicMetadataRefreshInterval.TotalMilliseconds
-            };
+            var consumerConfig = new ConsumerConfig();
+            kafkaConsumerConfig.ConsumerConfigUserTuning(consumerConfig);
+            kafkaConsumerConfig.ConsumerConfigTuning(consumerConfig);
 
-            var consumerBuilder = new ConsumerBuilder<byte[], byte[]>(consumerConfig)
-                .SetKeyDeserializer(Deserializers.ByteArray)
-                .SetValueDeserializer(Deserializers.ByteArray)
-                .SetErrorHandler(
-                    (_, error) => this.log.Error($"ConfluentConsumer error: {error.ToPrettyJson()}"))
-                .SetLogHandler(
-                    (_, logMessage) => this.log.Debug($"ConfluentConsumer logMessage: {logMessage.ToPrettyJson()}"))
-                .SetPartitionsAssignedHandler(
-                    (_, topicPartitions) =>
-                    {
-                        var offsetsToConsumeFrom = committedOffsets.GetOffsetsToConsumeFrom(topicPartitions);
-                        this.log.Info($"Assigned {topicPartitions.Count} partitions with offsetsToConsumeFrom: {string.Join("; ", offsetsToConsumeFrom.Select(x => x.ToString()))}");
-                        firstAssignmentSignal.Set();
-                        return offsetsToConsumeFrom;
-                    });
-
-            consumer = consumerBuilder.Build();
+            consumer = BuildConsumer(consumerConfig);
         }
 
         public void Dispose()
@@ -95,6 +72,26 @@ namespace Vektonn.DataSource.Kafka
             consumerLoopThread.Start();
 
             await initializationTcs.Task;
+        }
+
+        private IConsumer<byte[], byte[]> BuildConsumer(ConsumerConfig consumerConfig)
+        {
+            var consumerBuilder = new ConsumerBuilder<byte[], byte[]>(consumerConfig)
+                .SetKeyDeserializer(Deserializers.ByteArray)
+                .SetValueDeserializer(Deserializers.ByteArray)
+                .SetErrorHandler(
+                    (_, error) => LogExtensions.Error(this.log, $"ConfluentConsumer error: {error.ToPrettyJson()}"))
+                .SetLogHandler(
+                    (_, logMessage) => LogExtensions.Debug(this.log, $"ConfluentConsumer logMessage: {logMessage.ToPrettyJson()}"))
+                .SetPartitionsAssignedHandler(
+                    (_, topicPartitions) =>
+                    {
+                        var offsetsToConsumeFrom = committedOffsets.GetOffsetsToConsumeFrom(topicPartitions);
+                        LogExtensions.Info(this.log, $"Assigned {topicPartitions.Count} partitions with offsetsToConsumeFrom: {string.Join("; ", offsetsToConsumeFrom.Select(x => x.ToString()))}");
+                        firstAssignmentSignal.Set();
+                        return offsetsToConsumeFrom;
+                    });
+            return consumerBuilder.Build();
         }
 
         private async Task ConsumeLoopAsync(TaskCompletionSource initializationTcs, CancellationToken cancellationToken)

--- a/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
@@ -42,8 +42,8 @@ namespace Vektonn.DataSource.Kafka
             committedOffsets = new CommittedOffsets(this.log);
 
             var consumerConfig = new ConsumerConfig();
-            kafkaConsumerConfig.ConsumerConfigUserTuning(consumerConfig);
-            kafkaConsumerConfig.ConsumerConfigTuning(consumerConfig);
+            kafkaConsumerConfig.CustomizeConsumerConfig(consumerConfig);
+            kafkaConsumerConfig.CustomizeConsumerConfigInternal(consumerConfig);
 
             consumer = BuildConsumer(consumerConfig);
         }

--- a/src/Vektonn.DataSource/Kafka/KafkaConsumerConfig.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaConsumerConfig.cs
@@ -21,10 +21,13 @@ namespace Vektonn.DataSource.Kafka
         public TimeSpan MaxRetryDelay { get; set; } = TimeSpan.FromSeconds(10);
         public TimeSpan WatermarkOffsetsQueryTimeout { get; set; } = TimeSpan.FromSeconds(1);
         public int ConsumeBatchSize { get; set; } = 10_000;
-        public Action<ConsumerConfig> CustomizeConsumerConfig { get; set; } = config => {};
+        public Action<ConsumerConfig> CustomizeConfluentConsumerConfig { get; set; } = config => {};
 
-        internal void CustomizeConsumerConfigInternal(ConsumerConfig consumerConfig)
+        internal ConsumerConfig GetConfluentConsumerConfig()
         {
+            var consumerConfig = new ConsumerConfig();
+            CustomizeConfluentConsumerConfig(consumerConfig);
+
             consumerConfig.BootstrapServers = string.Join(",", BootstrapServers);
             consumerConfig.GroupId = $"Vektonn-{Guid.NewGuid():N}";
             consumerConfig.EnableAutoCommit = false;
@@ -32,6 +35,8 @@ namespace Vektonn.DataSource.Kafka
             consumerConfig.AutoOffsetReset = AutoOffsetReset.Earliest;
             consumerConfig.FetchWaitMaxMs = (int)MaxFetchDelay.TotalMilliseconds;
             consumerConfig.TopicMetadataRefreshIntervalMs = (int)TopicMetadataRefreshInterval.TotalMilliseconds;
+
+            return consumerConfig;
         }
     }
 }

--- a/src/Vektonn.DataSource/Kafka/KafkaConsumerConfig.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaConsumerConfig.cs
@@ -21,9 +21,9 @@ namespace Vektonn.DataSource.Kafka
         public TimeSpan MaxRetryDelay { get; set; } = TimeSpan.FromSeconds(10);
         public TimeSpan WatermarkOffsetsQueryTimeout { get; set; } = TimeSpan.FromSeconds(1);
         public int ConsumeBatchSize { get; set; } = 10_000;
-        public Action<ConsumerConfig> ConsumerConfigUserTuning { get; set; } = config => {};
+        public Action<ConsumerConfig> CustomizeConsumerConfig { get; set; } = config => {};
 
-        public void ConsumerConfigTuning(ConsumerConfig consumerConfig)
+        internal void CustomizeConsumerConfigInternal(ConsumerConfig consumerConfig)
         {
             consumerConfig.BootstrapServers = string.Join(",", BootstrapServers);
             consumerConfig.GroupId = $"Vektonn-{Guid.NewGuid():N}";

--- a/src/Vektonn.DataSource/Kafka/KafkaConsumerConfig.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaConsumerConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Confluent.Kafka;
 
 namespace Vektonn.DataSource.Kafka
 {
@@ -20,5 +21,17 @@ namespace Vektonn.DataSource.Kafka
         public TimeSpan MaxRetryDelay { get; set; } = TimeSpan.FromSeconds(10);
         public TimeSpan WatermarkOffsetsQueryTimeout { get; set; } = TimeSpan.FromSeconds(1);
         public int ConsumeBatchSize { get; set; } = 10_000;
+        public Action<ConsumerConfig> ConsumerConfigUserTuning { get; set; } = config => {};
+
+        public void ConsumerConfigTuning(ConsumerConfig consumerConfig)
+        {
+            consumerConfig.BootstrapServers = string.Join(",", BootstrapServers);
+            consumerConfig.GroupId = $"Vektonn-{Guid.NewGuid():N}";
+            consumerConfig.EnableAutoCommit = false;
+            consumerConfig.AutoCommitIntervalMs = 0;
+            consumerConfig.AutoOffsetReset = AutoOffsetReset.Earliest;
+            consumerConfig.FetchWaitMaxMs = (int)MaxFetchDelay.TotalMilliseconds;
+            consumerConfig.TopicMetadataRefreshIntervalMs = (int)TopicMetadataRefreshInterval.TotalMilliseconds;
+        }
     }
 }

--- a/src/Vektonn.DataSource/Kafka/KafkaProducer.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaProducer.cs
@@ -26,8 +26,8 @@ namespace Vektonn.DataSource.Kafka
             topicMetadataRefreshInterval = kafkaProducerConfig.ProduceTimeout.Multiply(0.3);
 
             var producerConfig = new ProducerConfig();
-            kafkaProducerConfig.ProducerConfigUserTuning(producerConfig);
-            kafkaProducerConfig.ProducerConfigTuning(producerConfig, topicMetadataRefreshInterval);
+            kafkaProducerConfig.CustomizeProducerConfig(producerConfig);
+            kafkaProducerConfig.CustomizeProducerConfigInternal(producerConfig, topicMetadataRefreshInterval);
 
             producer = BuildProducer(producerConfig);
         }

--- a/src/Vektonn.DataSource/Kafka/KafkaProducer.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaProducer.cs
@@ -25,10 +25,7 @@ namespace Vektonn.DataSource.Kafka
 
             topicMetadataRefreshInterval = kafkaProducerConfig.ProduceTimeout.Multiply(0.3);
 
-            var producerConfig = new ProducerConfig();
-            kafkaProducerConfig.CustomizeProducerConfig(producerConfig);
-            kafkaProducerConfig.CustomizeProducerConfigInternal(producerConfig, topicMetadataRefreshInterval);
-
+            var producerConfig = kafkaProducerConfig.GetConfluentProducerConfig(topicMetadataRefreshInterval);
             producer = BuildProducer(producerConfig);
         }
 

--- a/src/Vektonn.DataSource/Kafka/KafkaProducer.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaProducer.cs
@@ -24,27 +24,12 @@ namespace Vektonn.DataSource.Kafka
             this.kafkaProducerConfig = kafkaProducerConfig;
 
             topicMetadataRefreshInterval = kafkaProducerConfig.ProduceTimeout.Multiply(0.3);
-            var producerConfig = new ProducerConfig
-            {
-                BootstrapServers = string.Join(",", kafkaProducerConfig.BootstrapServers),
-                Acks = Acks.All,
-                MessageSendMaxRetries = 0,
-                LingerMs = kafkaProducerConfig.LingerDelay.TotalMilliseconds,
-                RequestTimeoutMs = (int)kafkaProducerConfig.ProduceTimeout.TotalMilliseconds,
-                MessageTimeoutMs = (int)kafkaProducerConfig.ProduceTimeout.TotalMilliseconds,
-                TopicMetadataPropagationMaxMs = (int)topicMetadataRefreshInterval.TotalMilliseconds,
-                TopicMetadataRefreshIntervalMs = (int)topicMetadataRefreshInterval.TotalMilliseconds,
-            };
 
-            var producerBuilder = new ProducerBuilder<byte[], byte[]>(producerConfig)
-                .SetKeySerializer(Serializers.ByteArray)
-                .SetValueSerializer(Serializers.ByteArray)
-                .SetErrorHandler(
-                    (_, error) => this.log.Error($"ConfluentProducer error: {error.ToPrettyJson()}"))
-                .SetLogHandler(
-                    (_, logMessage) => this.log.Debug($"ConfluentProducer logMessage: {logMessage.ToPrettyJson()}"));
+            var producerConfig = new ProducerConfig();
+            kafkaProducerConfig.ProducerConfigUserTuning(producerConfig);
+            kafkaProducerConfig.ProducerConfigTuning(producerConfig, topicMetadataRefreshInterval);
 
-            producer = producerBuilder.Build();
+            producer = BuildProducer(producerConfig);
         }
 
         public void Dispose()
@@ -69,6 +54,18 @@ namespace Vektonn.DataSource.Kafka
             await Task.Delay(topicMetadataRefreshInterval);
 
             await TryProduceAsync(topicName, messages, tolerateUnknownTopicError: false);
+        }
+
+        private IProducer<byte[], byte[]> BuildProducer(ProducerConfig producerConfig)
+        {
+            return new ProducerBuilder<byte[], byte[]>(producerConfig)
+                .SetKeySerializer(Serializers.ByteArray)
+                .SetValueSerializer(Serializers.ByteArray)
+                .SetErrorHandler(
+                    (_, error) => LogExtensions.Error(log, $"ConfluentProducer error: {error.ToPrettyJson()}"))
+                .SetLogHandler(
+                    (_, logMessage) => LogExtensions.Debug(log, $"ConfluentProducer logMessage: {logMessage.ToPrettyJson()}"))
+                .Build();
         }
 
         private async Task<bool> TryProduceAsync(string topicName, Message<byte[], byte[]>[] messages, bool tolerateUnknownTopicError)

--- a/src/Vektonn.DataSource/Kafka/KafkaProducerConfig.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaProducerConfig.cs
@@ -19,10 +19,13 @@ namespace Vektonn.DataSource.Kafka
         public KafkaTopicCreationConfig TopicCreationConfig { get; }
         public TimeSpan ProduceTimeout { get; set; } = TimeSpan.FromSeconds(10);
         public TimeSpan LingerDelay { get; set; } = TimeSpan.FromMilliseconds(10);
-        public Action<ProducerConfig> CustomizeProducerConfig { get; set; } = config => {};
+        public Action<ProducerConfig> CustomizeConfluentProducerConfig { get; set; } = config => {};
 
-        internal void CustomizeProducerConfigInternal(ProducerConfig producerConfig, TimeSpan topicMetadataRefreshInterval)
+        internal ProducerConfig GetConfluentProducerConfig(TimeSpan topicMetadataRefreshInterval)
         {
+            var producerConfig = new ProducerConfig();
+            CustomizeConfluentProducerConfig(producerConfig);
+
             producerConfig.BootstrapServers = string.Join(",", BootstrapServers);
             producerConfig.Acks = Acks.All;
             producerConfig.MessageSendMaxRetries = 0;
@@ -31,6 +34,8 @@ namespace Vektonn.DataSource.Kafka
             producerConfig.MessageTimeoutMs = (int)ProduceTimeout.TotalMilliseconds;
             producerConfig.TopicMetadataPropagationMaxMs = (int)topicMetadataRefreshInterval.TotalMilliseconds;
             producerConfig.TopicMetadataRefreshIntervalMs = (int)topicMetadataRefreshInterval.TotalMilliseconds;
+
+            return producerConfig;
         }
     }
 }

--- a/src/Vektonn.DataSource/Kafka/KafkaProducerConfig.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaProducerConfig.cs
@@ -19,9 +19,9 @@ namespace Vektonn.DataSource.Kafka
         public KafkaTopicCreationConfig TopicCreationConfig { get; }
         public TimeSpan ProduceTimeout { get; set; } = TimeSpan.FromSeconds(10);
         public TimeSpan LingerDelay { get; set; } = TimeSpan.FromMilliseconds(10);
-        public Action<ProducerConfig> ProducerConfigUserTuning { get; set; } = config => {};
+        public Action<ProducerConfig> CustomizeProducerConfig { get; set; } = config => {};
 
-        public void ProducerConfigTuning(ProducerConfig producerConfig, TimeSpan topicMetadataRefreshInterval)
+        internal void CustomizeProducerConfigInternal(ProducerConfig producerConfig, TimeSpan topicMetadataRefreshInterval)
         {
             producerConfig.BootstrapServers = string.Join(",", BootstrapServers);
             producerConfig.Acks = Acks.All;

--- a/src/Vektonn.DataSource/Kafka/KafkaProducerConfig.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaProducerConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Confluent.Kafka;
 
 namespace Vektonn.DataSource.Kafka
 {
@@ -18,5 +19,18 @@ namespace Vektonn.DataSource.Kafka
         public KafkaTopicCreationConfig TopicCreationConfig { get; }
         public TimeSpan ProduceTimeout { get; set; } = TimeSpan.FromSeconds(10);
         public TimeSpan LingerDelay { get; set; } = TimeSpan.FromMilliseconds(10);
+        public Action<ProducerConfig> ProducerConfigUserTuning { get; set; } = config => {};
+
+        public void ProducerConfigTuning(ProducerConfig producerConfig, TimeSpan topicMetadataRefreshInterval)
+        {
+            producerConfig.BootstrapServers = string.Join(",", BootstrapServers);
+            producerConfig.Acks = Acks.All;
+            producerConfig.MessageSendMaxRetries = 0;
+            producerConfig.LingerMs = LingerDelay.TotalMilliseconds;
+            producerConfig.RequestTimeoutMs = (int)ProduceTimeout.TotalMilliseconds;
+            producerConfig.MessageTimeoutMs = (int)ProduceTimeout.TotalMilliseconds;
+            producerConfig.TopicMetadataPropagationMaxMs = (int)topicMetadataRefreshInterval.TotalMilliseconds;
+            producerConfig.TopicMetadataRefreshIntervalMs = (int)topicMetadataRefreshInterval.TotalMilliseconds;
+        }
     }
 }


### PR DESCRIPTION
This change allows users to customize Kafka clients that is used internally. 
For example enable debug logs or set up a security protocol