### PR TITLE
DataSource.Kafka. ErrorHandler: Log as error when error is Fatal

### DIFF
--- a/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaConsumer.cs
@@ -77,7 +77,17 @@ namespace Vektonn.DataSource.Kafka
                 .SetKeyDeserializer(Deserializers.ByteArray)
                 .SetValueDeserializer(Deserializers.ByteArray)
                 .SetErrorHandler(
-                    (_, error) => LogExtensions.Error(this.log, $"ConfluentConsumer error: {error.ToPrettyJson()}"))
+                    (_, error) =>
+                    {
+                        if (error.IsFatal)
+                        {
+                            LogExtensions.Error(this.log, $"ConfluentConsumer error: {error.ToPrettyJson()}");
+                        }
+                        else
+                        {
+                            LogExtensions.Warn(this.log, $"ConfluentConsumer warn: {error.ToPrettyJson()}");
+                        }
+                    })
                 .SetLogHandler(
                     (_, logMessage) => LogExtensions.Debug(this.log, $"ConfluentConsumer logMessage: {logMessage.ToPrettyJson()}"))
                 .SetPartitionsAssignedHandler(

--- a/src/Vektonn.DataSource/Kafka/KafkaProducer.cs
+++ b/src/Vektonn.DataSource/Kafka/KafkaProducer.cs
@@ -59,7 +59,17 @@ namespace Vektonn.DataSource.Kafka
                 .SetKeySerializer(Serializers.ByteArray)
                 .SetValueSerializer(Serializers.ByteArray)
                 .SetErrorHandler(
-                    (_, error) => LogExtensions.Error(log, $"ConfluentProducer error: {error.ToPrettyJson()}"))
+                    (_, error) =>
+                    {
+                        if (error.IsFatal)
+                        {
+                            LogExtensions.Error(this.log, $"ConfluentProducer error: {error.ToPrettyJson()}");
+                        }
+                        else
+                        {
+                            LogExtensions.Warn(this.log, $"ConfluentProducer warn: {error.ToPrettyJson()}");
+                        }
+                    })
                 .SetLogHandler(
                     (_, logMessage) => LogExtensions.Debug(log, $"ConfluentProducer logMessage: {logMessage.ToPrettyJson()}"))
                 .Build();


### PR DESCRIPTION
Change logging level of KafkaErrors. 
If `KafkaError.IsFatal == true`, then log it as Error, otherwise log it as Warn